### PR TITLE
Add coverage badge and test report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,32 @@ jobs:
 
       - name: Install packages
         run: |
+          git config --global url."https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github".insteadOf https://github
           python -m pip install --upgrade pip
+          pip install coverage-badge
           pip install pytest
+          pip install pytest-cov
+          pip install pytest-html
           pip install ./
 
       - name: Test with pytest
         run: |
-          pytest tests
+          pytest --cov=pysagas --cov-report xml --cov-report html --html=pytest_report.html --self-contained-html tests/
+      
+      - name: Generate coverage badge
+        run: |
+          coverage-badge -f -o coverage.svg
+  
+      - name: Clean up and organise
+        run: |
+          mkdir coverage
+          mv htmlcov/* coverage/
+          mkdir deploy
+          mv coverage deploy/
+          mv coverage.svg deploy/
+          mv pytest_report.html deploy/
+
+      - name: Publish to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: deploy

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@
     <img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg">
   </a>
 
-  <a>
-    <img src="https://github.com/kieran-mackle/pysagas/actions/workflows/tests.yml/badge.svg" alt="Test Status" class="center">
+  <a href="https://kieran-mackle.github.io/pysagas/pytest_report">
+    <img src="https://github.com/kieran-mackle/pysagas/actions/workflows/tests.yml/badge.svg" alt="Test Status" >
+  </a>
+
+  <a href="https://kieran-mackle.github.io/pysagas/coverage">
+    <img src="https://github.com/kieran-mackle/pysagas/raw/gh-pages/coverage.svg?raw=true" alt="Test Coverage" >
   </a>
   
 </p>


### PR DESCRIPTION
This PR adds the following badges to the README:

  <a href="https://kieran-mackle.github.io/pysagas/pytest_report">
    <img src="https://github.com/kieran-mackle/pysagas/actions/workflows/tests.yml/badge.svg" alt="Test Status" >
  </a>

  <a href="https://kieran-mackle.github.io/pysagas/coverage">
    <img src="https://github.com/kieran-mackle/pysagas/raw/gh-pages/coverage.svg?raw=true" alt="Test Coverage" >
  </a>

This PR also includes a deployment of test and coverage reports to gh-pages, which can be viewed by clicking the badges above. This supports Issue #25.